### PR TITLE
Update violin.py

### DIFF
--- a/pyfair/report/violin.py
+++ b/pyfair/report/violin.py
@@ -3,8 +3,6 @@
 import matplotlib
 import matplotlib.pyplot as plt
 
-from matplotlib.ticker import StrMethodFormatter
-
 from ..utility.fair_exception import FairException
 from .base_curve import FairBaseCurve
 
@@ -43,8 +41,8 @@ class FairViolinPlot(FairBaseCurve):
             showmeans=False,
             showmedians=True
         )
-        ax.axes.xaxis.set_ticklabels(columns)
         ax.axes.xaxis.set_ticks([item for item in range(1, len(columns) + 1)])
+        ax.axes.xaxis.set_ticklabels(columns)
         ax.set_title('Components And Aggregate Risk', fontsize=20)
         ax.axes.yaxis.set_major_formatter(matplotlib.ticker.StrMethodFormatter('${x:,.0f}'))
         plt.subplots_adjust(left=.2)


### PR DESCRIPTION
Rearranging the ticks/ticklabels to remove UserWarning Error. (From [Stack Overflow answer here](https://stackoverflow.com/a/68794383).)

Also removed unused import.

This resolves [Issue 48](https://github.com/theonaunheim/pyfair/issues/48).

Tested with Python 3.10.10 and matplotlib 3.7.1. 