### PR TITLE
Update base_report.py

### DIFF
--- a/pyfair/report/base_report.py
+++ b/pyfair/report/base_report.py
@@ -254,7 +254,7 @@ class FairBaseReport(object):
         except KeyError:
             raise FairException("No 'Risk' key. Model likely uncalculated.")
         # Get aggregate statistics and set titles
-        risk_results = risk_results.agg([np.mean, np.std, np.min, np.max])
+        risk_results = risk_results.agg(['mean', 'std', 'min', 'max'])
         risk_results.index = ['Mean', 'Stdev', 'Minimum', 'Maximum']
         # Format risk results into dataframe
         overview_df = risk_results.applymap(lambda x: self._format_strings['Risk'].format(x))


### PR DESCRIPTION
FutureWarning about aggregation functions (np.mean, np.std, np.min, np.max): The warning suggests that in future versions of pandas, the callable will be used directly, so to maintain the current behavior, we should pass the string name of the aggregation function instead of the numpy function. from
risk_results = risk_results.agg([np.mean, np.std, np.min, np.max]) to
risk_results = risk_results.agg(['mean', 'std', 'min', 'max'])